### PR TITLE
:bug: Now different users on the same bridge can run the same plugin

### DIFF
--- a/cmsysbot/system/plugin.py
+++ b/cmsysbot/system/plugin.py
@@ -26,6 +26,8 @@ class Plugin:
     )
     COMMENTS_REGEX = re.compile(r"\n\s*#")
 
+    COPY_MODE = 0o555
+
     def __init__(self, server_path: str):
         self.server_path = server_path
         self.data = self.parse_cmsysbot_body()
@@ -73,7 +75,7 @@ class Plugin:
         return None
 
     def run(self, session: Session):
-        session.copy_to_bridge(self.server_path, self.bridge_path, 0o777)
+        session.copy_to_bridge(self.server_path, self.bridge_path, Plugin.COPY_MODE)
 
         # Replace the session $arguments (username, password...)
         self.fill_session_arguments(session)

--- a/cmsysbot/utils/session.py
+++ b/cmsysbot/utils/session.py
@@ -117,8 +117,25 @@ class Session:
     def copy_to_bridge(self, source_path: str, bridge_path: str, permissions: int):
 
         sftp = self.client.open_sftp()
-        sftp.put(source_path, bridge_path, confirm=True)
-        sftp.chmod(bridge_path, permissions)
+
+        try:
+            # Check if the file is already on the bridge computer
+            sftp.stat(bridge_path)
+
+            logging.getLogger().info(
+                f"({self.username}) - Tried to copy the file {source_path} but is "
+                f"already present on the destiny path ({bridge_path})"
+            )
+
+        # Copy the file otherwise
+        except FileNotFoundError:
+            sftp.put(source_path, bridge_path, confirm=True)
+            sftp.chmod(bridge_path, permissions)
+
+            logging.getLogger().info(
+                f"({self.username}) - The file {source_path} has been copied to "
+                f"{bridge_path}"
+            )
 
         sftp.close()
 


### PR DESCRIPTION
The function `cmsysbot.utils.session.Session.copy_to_bridge()` now checks first if the file is __already present__ on the bridge computer. If so, don't perform any copy. Otherwise, the file will be __copied__ to the bridge.

When a __plugin__ is copied to the bridge (because its going to be executed), the copy of the bridge path will have assigned the permissions 555, allowing any user to execute it, but preventing undesired modifications.

Closes #4