### PR TITLE
:bug: Fix 'KeyError' exception on 'session' key

### DIFF
--- a/cmsysbot/controller/command.py
+++ b/cmsysbot/controller/command.py
@@ -27,8 +27,5 @@ def start(bot: Bot, update: Updater, user_data: dict):
         user_data (:obj:`dict`): The dictionary with user variables.
     """
 
-    if "session" not in user_data:
-        user_data["session"] = Session()
-
     # Show the main menu on a new message
     menu.new_main(bot, update, user_data)

--- a/cmsysbot/controller/conversation.py
+++ b/cmsysbot/controller/conversation.py
@@ -42,7 +42,7 @@ def start_plugin_from_callback(bot: Bot, update: Updater, user_data: dict):
 
 def start_plugin_from_download(bot: Bot, update: Updater, user_data: dict):
 
-    session = user_data["session"]
+    session = Session.get_from(user_data)
     message = update.message
 
     if not session.connected:
@@ -72,7 +72,7 @@ def start_plugin_from_download(bot: Bot, update: Updater, user_data: dict):
 
 def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 
-    session = user_data["session"]
+    session = Session.get_from(user_data)
 
     plugin = user_data["plugin"]
     plugin.fill_session_arguments(session)
@@ -88,7 +88,7 @@ def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 
 def execute_plugin(bot: Bot, update: Updater, user_data: dict):
 
-    session: Session = user_data["session"]
+    session = Session.get_from(user_data)
     plugin: Plugin = user_data["plugin"]
 
     for name, ip, stdout, stderr in plugin.run(session):
@@ -124,7 +124,7 @@ def login(bot: Bot, update: Updater) -> int:
 def get_username(bot: Bot, update: Updater, user_data: dict) -> int:
     """Get the username from the last messge. Ask for the password and wait"""
 
-    user_data["session"].username = update.message.text
+    Session.get_from(user_data).username = update.message.text
 
     view.ask_password().reply(update)
 
@@ -134,7 +134,7 @@ def get_username(bot: Bot, update: Updater, user_data: dict) -> int:
 def get_password(bot: Bot, update: Updater, user_data: dict) -> ConversationHandler:
     """Get the password from the last message. End conversation"""
 
-    user_data["session"].password = update.message.text
+    Session.get_from(user_data).password = update.message.text
 
     general.connect(bot, update, user_data)
 

--- a/cmsysbot/controller/general.py
+++ b/cmsysbot/controller/general.py
@@ -18,7 +18,7 @@ from telegram.ext import Updater
 
 from cmsysbot import view
 from cmsysbot.system import Plugin
-from cmsysbot.utils import State
+from cmsysbot.utils import State, Session
 
 from . import menu
 
@@ -37,7 +37,7 @@ def connect(bot: Bot, update: Updater, user_data: dict):
         user_data (:obj:`dict`): The dictionary with user variables.
     """
 
-    session = user_data["session"]
+    session = Session.get_from(user_data)
 
     # Try to connect to the client
     session.start_connection()
@@ -72,10 +72,10 @@ def disconnect(bot: Bot, update: Updater, user_data: dict):
         user_data (:obj:`dict`): The dictionary with user variables.
     """
 
-    bridge_ip = user_data["session"].bridge_ip
+    bridge_ip = Session.get_from(user_data).bridge_ip
 
     # Close the connection
-    user_data["session"].end_connetion()
+    Session.get_from(user_data).end_connetion()
 
     # Send the disconnect output
     view.disconnect_output(bridge_ip).edit(update)
@@ -97,7 +97,7 @@ def update_ips(bot: Bot, update: Updater, user_data: dict):
             the bot.
         user_data (:obj:`dict`): The dictionary with user variables.
     """
-    session = user_data["session"]
+    session = Session.get_from(user_data)
 
     # Get all the local ips for every local mac
     plugin = Plugin("plugins/_local_arp_scan")
@@ -147,7 +147,7 @@ def include_computers(bot: Bot, update: Updater, user_data: dict):
     # Extract the target from the string. Values: 'all' or '[mac_address]'
     target = re.search(State.INCLUDE_COMPUTERS, query.data).group(1)
 
-    computers = user_data["session"].computers
+    computers = Session.get_from(user_data).computers
 
     # Include all computers
     if target == "all":
@@ -185,7 +185,7 @@ def exclude_computers(bot: Bot, update: Updater, user_data: dict):
     # Extract the target from the string. Values: 'all' or '[mac_address]'
     target = re.search(State.EXCLUDE_COMPUTERS, query.data).group(1)
 
-    computers = user_data["session"].computers
+    computers = Session.get_from(user_data).computers
 
     # Exclude all computers
     if target == "all":

--- a/cmsysbot/utils/session.py
+++ b/cmsysbot/utils/session.py
@@ -19,6 +19,13 @@ class Session:
         self.connected = False
         self.client: paramiko.SSHClient = None
 
+    @staticmethod
+    def get_from(user_data):
+        if "session" not in user_data:
+            user_data["session"] = Session()
+
+        return user_data["session"]
+
     def start_connection(self):
 
         self.is_allowed = self.__user_acl()


### PR DESCRIPTION
Add a static function in `Session` class to get the `Session` object from a `user_data`, creating it
if isn't already defined (due to a server restart, for example). Works like a _"getter for a
singleton instance"_.

Also, avoids putting `user_data["session"]` directly, which is __error prone__.

Now the user will be able to use __old menus__ even if the server is restarted.

Closes #10