### PR TITLE
:sparkles: Add decorators to assert user's connection status

### DIFF
--- a/cmsysbot/controller/command.py
+++ b/cmsysbot/controller/command.py
@@ -10,8 +10,6 @@ Note:
 from telegram import Bot
 from telegram.ext import Updater
 
-from cmsysbot.utils import Session
-
 from . import menu
 
 

--- a/cmsysbot/controller/conversation.py
+++ b/cmsysbot/controller/conversation.py
@@ -16,6 +16,7 @@ from telegram.ext import ConversationHandler, Updater
 from cmsysbot import view
 from cmsysbot.system import Plugin
 from cmsysbot.utils import Session, State, states
+from cmsysbot.utils.decorators import connected, not_connected
 
 from . import general, menu
 
@@ -27,6 +28,7 @@ USERNAME, PASSWORD, ANSWER = range(3)
 # ######################################################################
 
 
+@connected
 def start_plugin_from_callback(bot: Bot, update: Updater, user_data: dict):
     query = update.callback_query
 
@@ -40,6 +42,7 @@ def start_plugin_from_callback(bot: Bot, update: Updater, user_data: dict):
     return collect_arguments(bot, update, user_data)
 
 
+@connected
 def start_plugin_from_download(bot: Bot, update: Updater, user_data: dict):
 
     session = Session.get_from(user_data)
@@ -70,6 +73,7 @@ def start_plugin_from_download(bot: Bot, update: Updater, user_data: dict):
     return collect_arguments(bot, update, user_data)
 
 
+@connected
 def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 
     session = Session.get_from(user_data)
@@ -86,6 +90,7 @@ def collect_arguments(bot: Bot, update: Updater, user_data: dict):
     return execute_plugin(bot, update, user_data=user_data)
 
 
+@connected
 def execute_plugin(bot: Bot, update: Updater, user_data: dict):
 
     session = Session.get_from(user_data)
@@ -99,6 +104,7 @@ def execute_plugin(bot: Bot, update: Updater, user_data: dict):
     return ConversationHandler.END
 
 
+@connected
 def get_answer(bot: Bot, update: Updater, user_data: dict) -> int:
 
     argument = user_data["ask_argument"]

--- a/cmsysbot/controller/general.py
+++ b/cmsysbot/controller/general.py
@@ -18,11 +18,13 @@ from telegram.ext import Updater
 
 from cmsysbot import view
 from cmsysbot.system import Plugin
-from cmsysbot.utils import State, Session
+from cmsysbot.utils import Session, State
+from cmsysbot.utils.decorators import connected, not_connected
 
 from . import menu
 
 
+@not_connected
 def connect(bot: Bot, update: Updater, user_data: dict):
     """
     Tries to open a SSH connection from the bot server to the bridge computer.
@@ -58,6 +60,7 @@ def connect(bot: Bot, update: Updater, user_data: dict):
     menu.new_main(bot, update, user_data)
 
 
+@connected
 def disconnect(bot: Bot, update: Updater, user_data: dict):
     """
     Closes the open SSH connection to the bridge computer.
@@ -84,6 +87,7 @@ def disconnect(bot: Bot, update: Updater, user_data: dict):
     menu.new_main(bot, update, user_data)
 
 
+@connected
 def update_ips(bot: Bot, update: Updater, user_data: dict):
     """
     Get all the macs and its associated ips from the local network. Then,
@@ -124,6 +128,7 @@ def update_ips(bot: Bot, update: Updater, user_data: dict):
     menu.new_main(bot, update, user_data)
 
 
+@connected
 def include_computers(bot: Bot, update: Updater, user_data: dict):
     """
     Change the attribute :obj:`included` for one/all computers to ``True``. If
@@ -162,6 +167,7 @@ def include_computers(bot: Bot, update: Updater, user_data: dict):
     view.filter_computers(computers).edit(update)
 
 
+@connected
 def exclude_computers(bot: Bot, update: Updater, user_data: dict):
     """
     Change the attribute :obj:`included` for one/all computers to ``False``. If

--- a/cmsysbot/controller/menu.py
+++ b/cmsysbot/controller/menu.py
@@ -23,7 +23,8 @@ from telegram.ext import Updater
 
 from cmsysbot import view
 from cmsysbot.system import Plugin
-from cmsysbot.utils import Computers, State, states, Session
+from cmsysbot.utils import Computers, Session, State, states
+from cmsysbot.utils.decorators import connected, not_connected
 
 
 def new_main(bot: Bot, update: Updater, user_data: dict):
@@ -78,6 +79,7 @@ def main(bot: Bot, update: Updater, user_data: dict):
         ).edit(update)
 
 
+@not_connected
 def select_department(bot: Bot, update: Updater, user_data: dict):
     """
     Show the nodes on the first level of the :obj:`structure` field on the
@@ -99,6 +101,7 @@ def select_department(bot: Bot, update: Updater, user_data: dict):
     ).edit(update)
 
 
+@not_connected
 def structure(bot: Bot, update: Updater, user_data: dict):
     """
     Show the nodes on the level indicated by the route from the
@@ -163,6 +166,7 @@ def structure(bot: Bot, update: Updater, user_data: dict):
     ).edit(update)
 
 
+@not_connected
 def ip_selection(bot: Bot, update: Updater, user_data: dict):
     """
     Show a menu with the list of the computers that have a defined 'ip' field
@@ -189,6 +193,7 @@ def ip_selection(bot: Bot, update: Updater, user_data: dict):
     ).edit(update)
 
 
+@not_connected
 def confirm_connect_ip(bot: Bot, update: Updater, user_data: dict):
 
     # Get the clicked ip
@@ -201,6 +206,7 @@ def confirm_connect_ip(bot: Bot, update: Updater, user_data: dict):
     ).edit(update)
 
 
+@connected
 def filter_computers(bot: Bot, update: Updater, user_data: dict):
 
     # View

--- a/cmsysbot/utils/decorators.py
+++ b/cmsysbot/utils/decorators.py
@@ -1,0 +1,30 @@
+from functools import wraps
+
+from telegram import Bot
+from telegram.ext import Updater
+
+from cmsysbot.controller import menu
+
+from . import Session
+
+
+def connected(fun):
+    @wraps(fun)
+    def wrapper(bot: Bot, update: Updater, user_data):
+        if Session.get_from(user_data).connected:
+            fun(bot, update, user_data)
+        else:
+            menu.main(bot, update, user_data)
+
+    return wrapper
+
+
+def not_connected(fun):
+    @wraps(fun)
+    def wrapper(bot: Bot, update: Updater, user_data):
+        if not Session.get_from(user_data).connected:
+            fun(bot, update, user_data)
+        else:
+            menu.main(bot, update, user_data)
+
+    return wrapper


### PR DESCRIPTION
Two new decorators:

* `@connected`: Assert that the user is connected to a bridge computer.

* `@not_connected`: Assert that the user is not connected to a bridge computer.

This functions helps to prevent some bugs after restarting the server.

Closes #11