### PR TITLE
Add feature to check the computer status

### DIFF
--- a/cmsysbot/controller/controller.py
+++ b/cmsysbot/controller/controller.py
@@ -183,7 +183,10 @@ def add_conversation_callbacks(dp: Dispatcher):
             ],
             conversation.PASSWORD: [
                 MessageHandler(
-                    Filters.text, conversation.get_password, pass_user_data=True
+                    Filters.text,
+                    conversation.get_password,
+                    pass_user_data=True,
+                    pass_job_queue=True,
                 )
             ],
         },

--- a/cmsysbot/controller/conversation.py
+++ b/cmsysbot/controller/conversation.py
@@ -16,7 +16,7 @@ from telegram.ext import ConversationHandler, Updater
 from cmsysbot import view
 from cmsysbot.system import Plugin
 from cmsysbot.utils import Session, State, states
-from cmsysbot.utils.decorators import connected, not_connected
+from cmsysbot.utils.decorators import connected
 
 from . import general, menu
 
@@ -31,7 +31,6 @@ USERNAME, PASSWORD, ANSWER = range(3)
 @connected
 def start_plugin_from_callback(bot: Bot, update: Updater, user_data: dict):
     query = update.callback_query
-    print("Start plugin")
 
     # Plugin path in server
     plugin_path_server = re.search(State.START_PLUGIN, query.data).group(1)
@@ -74,19 +73,13 @@ def start_plugin_from_download(bot: Bot, update: Updater, user_data: dict):
 @connected
 def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 
-    print("Collect arguments")
-
     plugin = user_data["plugin"]
 
     for argument in plugin.arguments:
-        print("loop")
         if argument[0] != "$" and not plugin.arguments[argument]:
-            print("asdking")
             user_data["ask_argument"] = argument
             view.ask_argument(argument).reply(update)
             return ANSWER
-
-    print("end asking")
 
     return execute_plugin(bot, update, user_data=user_data)
 
@@ -94,7 +87,6 @@ def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 @connected
 def execute_plugin(bot: Bot, update: Updater, user_data: dict):
 
-    print("Plugin run")
     session = Session.get_from(user_data)
     plugin: Plugin = user_data["plugin"]
 
@@ -109,7 +101,6 @@ def execute_plugin(bot: Bot, update: Updater, user_data: dict):
 @connected
 def get_answer(bot: Bot, update: Updater, user_data: dict) -> int:
 
-    print("Get answer")
     argument = user_data["ask_argument"]
     user_data["plugin"][argument] = f'"{update.message.text}"'
 

--- a/cmsysbot/controller/conversation.py
+++ b/cmsysbot/controller/conversation.py
@@ -131,11 +131,13 @@ def get_username(bot: Bot, update: Updater, user_data: dict) -> int:
     return PASSWORD
 
 
-def get_password(bot: Bot, update: Updater, user_data: dict) -> ConversationHandler:
+def get_password(
+    bot: Bot, update: Updater, user_data: dict, job_queue
+) -> ConversationHandler:
     """Get the password from the last message. End conversation"""
 
     Session.get_from(user_data).password = update.message.text
 
-    general.connect(bot, update, user_data)
+    general.connect(bot, update, user_data, job_queue)
 
     return ConversationHandler.END

--- a/cmsysbot/controller/conversation.py
+++ b/cmsysbot/controller/conversation.py
@@ -31,6 +31,7 @@ USERNAME, PASSWORD, ANSWER = range(3)
 @connected
 def start_plugin_from_callback(bot: Bot, update: Updater, user_data: dict):
     query = update.callback_query
+    print("Start plugin")
 
     # Plugin path in server
     plugin_path_server = re.search(State.START_PLUGIN, query.data).group(1)
@@ -73,16 +74,19 @@ def start_plugin_from_download(bot: Bot, update: Updater, user_data: dict):
 @connected
 def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 
-    session = Session.get_from(user_data)
+    print("Collect arguments")
 
     plugin = user_data["plugin"]
-    plugin.fill_session_arguments(session)
 
     for argument in plugin.arguments:
+        print("loop")
         if argument[0] != "$" and not plugin.arguments[argument]:
+            print("asdking")
             user_data["ask_argument"] = argument
             view.ask_argument(argument).reply(update)
             return ANSWER
+
+    print("end asking")
 
     return execute_plugin(bot, update, user_data=user_data)
 
@@ -90,6 +94,7 @@ def collect_arguments(bot: Bot, update: Updater, user_data: dict):
 @connected
 def execute_plugin(bot: Bot, update: Updater, user_data: dict):
 
+    print("Plugin run")
     session = Session.get_from(user_data)
     plugin: Plugin = user_data["plugin"]
 
@@ -104,6 +109,7 @@ def execute_plugin(bot: Bot, update: Updater, user_data: dict):
 @connected
 def get_answer(bot: Bot, update: Updater, user_data: dict) -> int:
 
+    print("Get answer")
     argument = user_data["ask_argument"]
     user_data["plugin"][argument] = f'"{update.message.text}"'
 

--- a/cmsysbot/controller/general.py
+++ b/cmsysbot/controller/general.py
@@ -49,14 +49,12 @@ def connect(bot: Bot, update: Updater, user_data: dict):
 
     if session.connected:
         # Check if the bridge computer has all the required dependencies
-        print("Start session init")
         plugin = Plugin("plugins/_bridge_initialization")
 
         name, ip, stdout, stderr = next(plugin.run(session))
         view.plugin_output(
             name, ip, "Bridge Initialization", stdout, stderr, hide_header=True
         ).reply(update)
-        print("End session init")
 
     # Show the main menu again
     menu.new_main(bot, update, user_data)

--- a/cmsysbot/controller/general.py
+++ b/cmsysbot/controller/general.py
@@ -49,12 +49,14 @@ def connect(bot: Bot, update: Updater, user_data: dict):
 
     if session.connected:
         # Check if the bridge computer has all the required dependencies
+        print("Start session init")
         plugin = Plugin("plugins/_bridge_initialization")
 
         name, ip, stdout, stderr = next(plugin.run(session))
         view.plugin_output(
             name, ip, "Bridge Initialization", stdout, stderr, hide_header=True
         ).reply(update)
+        print("End session init")
 
     # Show the main menu again
     menu.new_main(bot, update, user_data)

--- a/cmsysbot/controller/menu.py
+++ b/cmsysbot/controller/menu.py
@@ -45,12 +45,7 @@ def new_main(bot: Bot, update: Updater, user_data: dict):
     if not session.connected:
         view.not_connected().reply(update)
     else:
-        view.connected(
-            session.route,
-            Plugin.get_local_plugins(),
-            session.username,
-            session.bridge_ip,
-        ).reply(update)
+        view.connected(session, Plugin.get_local_plugins()).reply(update)
 
 
 def main(bot: Bot, update: Updater, user_data: dict):
@@ -71,12 +66,7 @@ def main(bot: Bot, update: Updater, user_data: dict):
     if not session.connected:
         view.not_connected().edit(update)
     else:
-        view.connected(
-            session.route,
-            Plugin.get_local_plugins(),
-            session.username,
-            session.bridge_ip,
-        ).edit(update)
+        view.connected(session, Plugin.get_local_plugins()).edit(update)
 
 
 @not_connected

--- a/cmsysbot/system/plugin.py
+++ b/cmsysbot/system/plugin.py
@@ -102,6 +102,9 @@ class Plugin:
 
     def _run_on_remote(self, computer: Computer, session: Session):
 
+        if not computer.on():
+            return (computer.name, computer.ip, "The computer is off", "")
+
         session.copy_to_remote(computer.ip, self.bridge_path, self.remote_path)
 
         # Replace the computer arguments (ip, mac...)

--- a/cmsysbot/system/plugin.py
+++ b/cmsysbot/system/plugin.py
@@ -15,6 +15,7 @@ class PluginVar:
     TARGET_IP = "$TARGET_IP"
     TARGET_MAC = "$TARGET_MAC"
     MACS_LIST = "$MACS_LIST"
+    IPS_LIST = "$IPS_LIST"
     SOURCE_BRIDGE = "bridge"
     SOURCE_REMOTE = "remote"
     ROOT = False
@@ -126,7 +127,12 @@ class Plugin:
 
         if PluginVar.MACS_LIST in self.arguments:
             self.arguments[PluginVar.MACS_LIST] = " ".join(
-                list(map(lambda c: c.mac, session.computers.get_included_computers()))
+                list(map(lambda c: c.mac, session.computers.get_included()))
+            )
+
+        if PluginVar.IPS_LIST in self.arguments:
+            self.arguments[PluginVar.IPS_LIST] = " ".join(
+                list(map(lambda c: c.ip, session.computers.get_included()))
             )
 
     def fill_computer_arguments(self, computer: Computer):

--- a/cmsysbot/utils/computers_json.py
+++ b/cmsysbot/utils/computers_json.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from typing import Any, Dict, Iterator, List, Union
 
 from .base_json import BaseJson
@@ -9,6 +10,10 @@ class Computer:
     This class represents a computer. Provides getters and setters to avoid interacting
     directly with the dictionary
     """
+
+    class Status(Enum):
+        OFF = "off"
+        ON = "on"
 
     def __init__(self, computer_data: Dict[str, Union[str, bool]] = {}):
         """
@@ -21,6 +26,7 @@ class Computer:
         self.ip: str = "N/A"
         self.mac: str = "N/A"
         self.included: bool = True
+        self.status = Computer.Status.OFF
 
         # If a dictionary is passed, save the keys (name, ip, mac...) as attributes
         # values
@@ -30,6 +36,11 @@ class Computer:
                 setattr(self, key, computer_data[key])
             except AttributeError:
                 pass
+
+    def on(self) -> bool:
+        """Shortcut to test if a computer is turned on"""
+
+        return self.status == Computer.Status.ON
 
     def __str__(self) -> str:
         """Return the Computer object as a string for identification."""
@@ -44,7 +55,12 @@ class Computer:
         saved on the JSON file.
         """
 
-        return {"name": self.name, "ip": self.ip, "mac": self.mac}
+        return {
+            "name": self.name,
+            "ip": self.ip,
+            "mac": self.mac,
+            "status": self.status,
+        }
 
 
 class Computers(BaseJson):
@@ -84,9 +100,8 @@ class Computers(BaseJson):
 
         with open(filepath, "w") as outfile:
             json_scheme: Dict[str, List] = {}
-            json_scheme["computers"] = []
+            json_scheme["computers"] = [Computer().asdict()]  # Add a default computer
 
-            json_scheme["computers"].append(Computer().asdict())
             json.dump(json_scheme, outfile, indent=2)
 
             return json_scheme

--- a/cmsysbot/utils/computers_json.py
+++ b/cmsysbot/utils/computers_json.py
@@ -11,9 +11,9 @@ class Computer:
     directly with the dictionary
     """
 
-    class Status(Enum):
-        OFF = "off"
+    class Status:
         ON = "on"
+        OFF = "off"
 
     def __init__(self, computer_data: Dict[str, Union[str, bool]] = {}):
         """

--- a/cmsysbot/utils/computers_json.py
+++ b/cmsysbot/utils/computers_json.py
@@ -79,23 +79,23 @@ class Computers(BaseJson):
         self.__index = 0
 
         super().__init__(filepath)
-        self.connected_computers = 0
 
         # Transform dict to array of Computer objects
         self.computers = [Computer(entry) for entry in self.data["computers"]]
+
+    @property
+    def n_connected_computers(self):
+        """Return the number of computers with Status.ON"""
+
+        return len(list(filter(lambda c: c.on(), self.computers)))
 
     def save(self):
         """
         Transform each Computer object to a Dict and write the changes to the file.
         """
-
         self.data["computers"] = [computer.asdict() for computer in self.computers]
 
         super().save()
-
-    @property
-    def n_connected_computers(self):
-        return len(list(filter(lambda c: c.on(), self.computers)))
 
     @staticmethod
     def create(filepath: str):

--- a/cmsysbot/utils/computers_json.py
+++ b/cmsysbot/utils/computers_json.py
@@ -12,8 +12,8 @@ class Computer:
     """
 
     class Status:
-        ON = "on"
-        OFF = "off"
+        ON = "alive"
+        OFF = "unreachable"
 
     def __init__(self, computer_data: Dict[str, Union[str, bool]] = {}):
         """
@@ -37,6 +37,7 @@ class Computer:
             except AttributeError:
                 pass
 
+    # TODO: Change to "is_on?"
     def on(self) -> bool:
         """Shortcut to test if a computer is turned on"""
 
@@ -78,21 +79,23 @@ class Computers(BaseJson):
         self.__index = 0
 
         super().__init__(filepath)
+        self.connected_computers = 0
 
         # Transform dict to array of Computer objects
-        self.computers: List[Computer] = [
-            Computer(entry) for entry in self.data["computers"]
-        ]
+        self.computers = [Computer(entry) for entry in self.data["computers"]]
 
     def save(self):
         """
         Transform each Computer object to a Dict and write the changes to the file.
         """
 
-        # TODO: Really necessary or doing the conversion twice?
         self.data["computers"] = [computer.asdict() for computer in self.computers]
 
         super().save()
+
+    @property
+    def n_connected_computers(self):
+        return len(list(filter(lambda c: c.on(), self.computers)))
 
     @staticmethod
     def create(filepath: str):

--- a/cmsysbot/utils/config_json.py
+++ b/cmsysbot/utils/config_json.py
@@ -112,6 +112,13 @@ class Config(BaseJson):
         return self.data["plugins_dir"]
 
     @property
+    def check_status_interval(self) -> str:
+        """Get the interval of time (in seconds) between each check of the network
+        status (Connected computers)"""
+
+        return self.data["check_status_interval"]
+
+    @property
     def admins(self) -> List[str]:
         """Return a list with all the users defined as admin on the config.json"""
 

--- a/cmsysbot/view/keyboard.py
+++ b/cmsysbot/view/keyboard.py
@@ -5,7 +5,7 @@ chat.
 
 from typing import List
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, ParseMode
 from telegram.ext import Updater
 
 
@@ -79,7 +79,9 @@ class Keyboard:
         """
 
         self._get_message(update).reply_text(
-            text=self.text, reply_markup=self._generate_keyboard()
+            text=self.text,
+            reply_markup=self._generate_keyboard(),
+            parse_mode=ParseMode.MARKDOWN,
         )
 
     def edit(self, update: Updater):
@@ -94,7 +96,9 @@ class Keyboard:
         """
 
         self._get_message(update).edit_text(
-            text=self.text, reply_markup=self._generate_keyboard()
+            text=self.text,
+            reply_markup=self._generate_keyboard(),
+            parse_mode=ParseMode.MARKDOWN,
         )
 
     @staticmethod

--- a/cmsysbot/view/menu.py
+++ b/cmsysbot/view/menu.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 from emoji import emojize
 
-from cmsysbot.utils import Computer, State
+from cmsysbot.utils import Computer, Session, State
 
 from .keyboard import Button, Keyboard
 
@@ -36,9 +36,7 @@ def not_connected() -> Keyboard:
     return Keyboard(text, main_buttons=main_buttons)
 
 
-def connected(
-    route: List[str], plugins: Dict[str, str], username: str, bridge_ip: str
-) -> Keyboard:
+def connected(session: Session, plugins: Dict[str, str]) -> Keyboard:
     """
     .. code-block:: python
 
@@ -70,9 +68,12 @@ def connected(
 
     # Text
     text = "Status: Connected\n"
-    text += f"Route: {'/'.join(route)}\n"
-    text += f"Username: {username}\n"
-    text += f"Bridge ip: {bridge_ip}\n"
+    text += f"Route: {'/'.join(session.route)}\n"
+    text += f"Username: {session.username}\n"
+    text += f"Bridge ip: {session.bridge_ip}\n"
+    text += (
+        f"Computers: {session.computers.n_connected_computers}/{len(session.computers)}"
+    )
 
     # Buttons
     main_buttons = [

--- a/cmsysbot/view/menu.py
+++ b/cmsysbot/view/menu.py
@@ -227,7 +227,7 @@ def filter_computers(computers: List[Computer]):
     """
 
     # Text
-    text = "Select the computers that will be included in future operations"
+    text = "Select the _computers_ that will be included in future operations"
 
     # Buttons
     main_buttons = [
@@ -239,19 +239,29 @@ def filter_computers(computers: List[Computer]):
     for computer in computers:
         button_text = ""
 
-        if computer.on():
-            button_text += emojize(":full_moon:", use_aliases=True)
+        callback_text = ""
+
+        # Add included/excluded status
+        if computer.included:
+            button_text += ":white_check_mark:"
+            callback_text = f"exclude-{computer.mac}"
         else:
-            button_text += emojize(":new_moon:", use_aliases=True)
+            button_text += ":x:"
+            callback_text = f"include-{computer.mac}"
+
+        button_text += " "
+
+        # Add turned on/off status
+        if computer.on():
+            button_text += ":full_moon:"
+        else:
+            button_text += ":new_moon:"
 
         button_text += f" {computer}"
 
-        if computer.included:
-            main_buttons.append(
-                Button(f"asdf {button_text}", f"exclude-{computer.mac}")
-            )
-        else:
-            main_buttons.append(Button(button_text, f"include-{computer.mac}"))
+        button_text = emojize(button_text, use_aliases=True)
+
+        main_buttons.append(Button(button_text, callback_text))
 
     footer_buttons = [Button("Return", State.MAIN)]
 

--- a/cmsysbot/view/menu.py
+++ b/cmsysbot/view/menu.py
@@ -3,7 +3,10 @@ In this module are defined all the menus (text + keyboard) created by the bot.
 For views that are text only, see the module :mod:`cmsysbot.view.message`.
 """
 
+
 from typing import Dict, List
+
+from emoji import emojize
 
 from cmsysbot.utils import Computer, State
 
@@ -233,17 +236,24 @@ def filter_computers(computers: List[Computer]):
     ]
 
     # Add the buttons according to the computer attributes
-    for computer in computers.get_computers():
-        main_buttons.append(Button(str(computer)))
+    for computer in computers:
+        button_text = ""
+
+        if computer.on():
+            button_text += emojize(":full_moon:", use_aliases=True)
+        else:
+            button_text += emojize(":new_moon:", use_aliases=True)
+
+        button_text += f" {computer}"
 
         if computer.included:
-            main_buttons.append(Button("Included", f"exclude-{computer.mac}"))
+            main_buttons.append(
+                Button(f"asdf {button_text}", f"exclude-{computer.mac}")
+            )
         else:
-            main_buttons.append(Button("Excluded", f"include-{computer.mac}"))
+            main_buttons.append(Button(button_text, f"include-{computer.mac}"))
 
     footer_buttons = [Button("Return", State.MAIN)]
 
     # Keyboard
-    return Keyboard(
-        text, n_cols=2, main_buttons=main_buttons, footer_buttons=footer_buttons
-    )
+    return Keyboard(text, main_buttons=main_buttons, footer_buttons=footer_buttons)

--- a/cmsysbot/view/message.py
+++ b/cmsysbot/view/message.py
@@ -141,6 +141,14 @@ def ask_password() -> Keyboard:
     return Keyboard(text)
 
 
+def update_computers_status_message() -> Keyboard:
+    # Text
+    text = "Getting information about the computers on the network..."
+
+    # Keyboard
+    return Keyboard(text)
+
+
 # ######################################################################
 #                         PLUGIN CONVERSATION
 # ######################################################################

--- a/config/config.json
+++ b/config/config.json
@@ -7,6 +7,7 @@
 	"remote_tmp_dir": "/tmp/",
 	"log_dir": "log/",
 	"plugins_dir": "plugins/",
+	"check_status_interval": 60,
 	"admins": [],
 	"structure": [
 		{

--- a/plugins/_bridge_initialization
+++ b/plugins/_bridge_initialization
@@ -31,4 +31,12 @@ if [[ $? != 0 ]]; then
   printf "\n* 'sshpass' installed."
 fi
 
+# Check if fping is installed
+dpkg -s fping &>/dev/null
+
+if [[ $? != 0 ]]; then
+  sudo apt-get -y fping sshpass &>/dev/null
+  printf "\n* 'fping' installed."
+fi
+
 printf "\n\xE2\x9C\x85 The bridge computer is ready."

--- a/plugins/_computers_status
+++ b/plugins/_computers_status
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# CMSysBot: {
+# "root": "False",
+# "source": "bridge",
+# "arguments": ["$IPS_LIST"]
+# }
+
+## Get the status of the computers connected to the network
+
+IPS_LIST=$@
+
+fping -r 1 $IPS_LIST

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-telegram-bot==11.1.0
 paramiko==2.4.2
+emoji>=0.5.2
+

--- a/tests/test_computers_json.py
+++ b/tests/test_computers_json.py
@@ -57,9 +57,8 @@ class TestComputers(unittest.TestCase):
     def test_create(self, json_dump_mock):
         filepath = path.join(self.test_dir, "new_config_file.json")
 
-        expected_computers_config_dict = {
-            "computers": [{"name": "N/A", "ip": "N/A", "mac": "N/A"}]
-        }
+        # Expected dict with one default computer
+        expected_computers_config_dict = {"computers": [Computer().asdict()]}
 
         created_computers_config_dict = Computers.create(filepath)
 


### PR DESCRIPTION
`NOTE`: This adds the `fping` program to the _bridge dependencies_ and will be installed on the  `_bridge_initialization`

* Add `status` variable to each Computer, and to the `computers.json`
* Each time a user connects to a _bridge computer_, the plugin `_computers_status` will run, pinging all the computers on the list and updating its status.
* A job will execute each `ping_interval` seconds. This variable can be redefined on the `config.json` file. This job will rerun the plugin `_computers_status` and update the status of the computers.
* The `Filter Computers` menu has been updated to reflex the status of the computer and if its included/excluded.